### PR TITLE
Add pagination to session messages endpoint

### DIFF
--- a/sources/app/api/routes/sessionRoutes.ts
+++ b/sources/app/api/routes/sessionRoutes.ts
@@ -309,12 +309,17 @@ export function sessionRoutes(app: Fastify) {
         schema: {
             params: z.object({
                 sessionId: z.string()
-            })
+            }),
+            querystring: z.object({
+                limit: z.coerce.number().int().min(1).max(500).default(150),
+                beforeSeq: z.coerce.number().int().min(1).optional(),
+            }).optional()
         },
         preHandler: app.authenticate
     }, async (request, reply) => {
         const userId = request.userId;
         const { sessionId } = request.params;
+        const { limit = 150, beforeSeq } = request.query || {};
 
         // Verify session belongs to user
         const session = await db.session.findFirst({
@@ -328,10 +333,15 @@ export function sessionRoutes(app: Fastify) {
             return reply.code(404).send({ error: 'Session not found' });
         }
 
+        const where: Prisma.SessionMessageWhereInput = { sessionId };
+        if (beforeSeq !== undefined) {
+            where.seq = { lt: beforeSeq };
+        }
+
         const messages = await db.sessionMessage.findMany({
-            where: { sessionId },
-            orderBy: { createdAt: 'desc' },
-            take: 150,
+            where,
+            orderBy: { seq: 'desc' },
+            take: limit + 1,
             select: {
                 id: true,
                 seq: true,
@@ -342,15 +352,23 @@ export function sessionRoutes(app: Fastify) {
             }
         });
 
+        const hasMore = messages.length > limit;
+        const resultMessages = hasMore ? messages.slice(0, limit) : messages;
+        const nextBeforeSeq = hasMore && resultMessages.length > 0
+            ? resultMessages[resultMessages.length - 1].seq
+            : null;
+
         return reply.send({
-            messages: messages.map((v) => ({
+            messages: resultMessages.map((v) => ({
                 id: v.id,
                 seq: v.seq,
                 content: v.content,
                 localId: v.localId,
                 createdAt: v.createdAt.getTime(),
                 updatedAt: v.updatedAt.getTime()
-            }))
+            })),
+            hasMore,
+            nextBeforeSeq
         });
     });
 


### PR DESCRIPTION
Introduced optional 'limit' and 'beforeSeq' query parameters to the session messages route, enabling pagination. The response now includes 'hasMore' and 'nextBeforeSeq' fields to facilitate client-side navigation through message history.