### PR TITLE
fix: include prisma directory in Docker runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/sources ./sources
+COPY --from=builder /app/prisma ./prisma
 
 # Expose the port the app will run on
 EXPOSE 3000


### PR DESCRIPTION
## Problem

When self-hosting happy-server using Docker, the container starts successfully but fails with database errors:

```
Invalid `prisma.session.findMany()` invocation:
The table `public.Session` does not exist in the current database.
```

This happens because the Dockerfile's `runner` stage doesn't include the `prisma` directory, making it impossible to run `prisma migrate deploy` inside the container to initialize the database.

## Root Cause

The official Dockerfile only copies these files to the runtime stage:
- `tsconfig.json`
- `package.json`
- `node_modules`
- `sources`

But it's missing `prisma/`, which contains `schema.prisma` and migration files needed for database setup.

## Solution

Add one line to copy the prisma directory in the runtime stage:

```dockerfile
COPY --from=builder /app/prisma ./prisma
```

This allows the container to:
1. Run `prisma migrate deploy` to initialize the database
2. Properly support self-hosted deployments

## Testing

After this fix:
1. Build the Docker image
2. Run with docker-compose
3. Execute `docker exec <container> yarn prisma migrate deploy`
4. All 36 migrations apply successfully
5. Service starts without database errors

## Impact

- Minimal change (1 line added)
- No performance impact
- Enables proper self-hosting workflow
- Maintains the multi-stage build optimization

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>